### PR TITLE
Added the sync step before uploading to S3

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 import "github.com/benchviz/filegenerator"
 
 func main() {
+	filegenerator.SyncWithAWS()
 	dirs := []string{"sql", "sql/parser", "kv", "roachpb", "storage",
 		"storage/engine", "util/cache", "util/caller", "util/decimal",
 		"util/encoding", "util/interval", "util/log"}


### PR DESCRIPTION
Before uploading, we now sync our local storage of
historical benchmark data with the data that is stored
in S3. The data in S3 is updated after every benchmark
test is completed on teamcity.

In addition, this commit now checks to make sure
environment variables are set throughout the
codebase for quicker debugging.
